### PR TITLE
Using `defaultsDeep` causes that values for `array` type of parameters are merged with default values

### DIFF
--- a/lib/middlewares/query/defaults.js
+++ b/lib/middlewares/query/defaults.js
@@ -1,4 +1,4 @@
-const {mergeWith, isUndefined} = require('lodash')
+const {mergeWith} = require('lodash')
 
 module.exports = defaultQueryParameters => (req, res, next) => {
     const customizer = objValue => objValue

--- a/lib/middlewares/query/defaults.js
+++ b/lib/middlewares/query/defaults.js
@@ -1,7 +1,7 @@
 const {mergeWith, isUndefined} = require('lodash')
 
 module.exports = defaultQueryParameters => (req, res, next) => {
-    const customizer = objValue => isUndefined(objValue) ? undefined : objValue
+    const customizer = objValue => objValue
     mergeWith(req.query, ...defaultQueryParameters, customizer)
     return next()
 }

--- a/lib/middlewares/query/defaults.js
+++ b/lib/middlewares/query/defaults.js
@@ -1,6 +1,7 @@
-const {defaultsDeep} = require('lodash')
+const {mergeWith, isUndefined} = require('lodash')
 
 module.exports = defaultQueryParameters => (req, res, next) => {
-    defaultsDeep(req.query, ...defaultQueryParameters)
+    const customizer = objValue => isUndefined(objValue) ? undefined : objValue
+    mergeWith(req.query, ...defaultQueryParameters, customizer)
     return next()
 }

--- a/test/middlewares/query/defaults.spec.js
+++ b/test/middlewares/query/defaults.spec.js
@@ -33,4 +33,26 @@ describe('query param defaults', () => {
         sinon.assert.called(next)
         expect(req.query).to.eql({test: 'abc'})
     })
+
+    it('should override default value if query param set', () => {
+        // given
+        const operation = {
+            parameters: [
+                {in: 'query', name: 'arrayParam', schema: {type: 'array', default: ['a1', 'a2']}},
+                {in: 'query', name: 'stringParam', schema: {type: 'string', default: 'def'}},
+                {in: 'query', name: 'intParam', schema: {type: 'integer', default: 1}}
+            ]
+        }
+        const middleware = queryDefaults(operation)
+
+        const req = {query: {arrayParam: ['b1'], stringParam: 'xyz', intParam: 0}}
+        const next = sinon.spy()
+
+        // when
+        middleware(req, {}, next)
+
+        // then
+        sinon.assert.called(next)
+        expect(req.query).to.eql({arrayParam: ['b1'], stringParam: 'xyz', intParam: 0})
+    })
 })


### PR DESCRIPTION
## Description
Using `_.defaultsDeep` causes that values for `array` type of parameters are merged with default values which leads to invalid api behaviour.

Somewhat related to https://github.com/lodash/lodash/pull/2802#issuecomment-259727419