### PR TITLE
Introduce new middleware for oauth scopes verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Currently following middlewares are available:
 - setting default query parameters values
 - removing unspecified query parameters,
 - content type validation,
-- routing to appropriate controller.
+- routing to appropriate controller,
+- oauth scopes authorization.
 
 ### Validation middlewares
 

--- a/docs/docs.hbs
+++ b/docs/docs.hbs
@@ -135,7 +135,8 @@ Currently following middlewares are available:
 - setting default query parameters values
 - removing unspecified query parameters,
 - content type validation,
-- routing to appropriate controller.
+- routing to appropriate controller,
+- oauth scopes authorization.
 
 ### Validation middlewares
 

--- a/errors/MissingRequiredScopes.js
+++ b/errors/MissingRequiredScopes.js
@@ -1,0 +1,7 @@
+module.exports = class MissingRequiredScopes extends Error {
+    constructor(requiredScopes) {
+        super()
+        this.name = this.constructor.name
+        this.requiredScopes = requiredScopes
+    }
+}

--- a/lib/middlewares/oauth/oauth-scopes.js
+++ b/lib/middlewares/oauth/oauth-scopes.js
@@ -1,0 +1,12 @@
+const {get} = require('lodash')
+const MissingRequiredScopes = require('../../../errors/MissingRequiredScopes')
+
+module.exports = (requiredScopes, grantedScopesLocation) => (req, res, next) => {
+    const grantedScopes = get(req, grantedScopesLocation)
+    if (grantedScopes) {
+        return grantedScopes.some(scope => requiredScopes.includes(scope))
+            ? next()
+            : next(new MissingRequiredScopes(requiredScopes))
+    }
+    return next()
+}

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -1,4 +1,4 @@
-const {pickBy, isMatch, keys, values, flatten} = require('lodash')
+const {pickBy, keys, values, flatten} = require('lodash')
 
 const oauthScopes = require('../../lib/middlewares/oauth/oauth-scopes')
 
@@ -26,7 +26,7 @@ module.exports = ({grantedScopesLocation = 'headers.x-oauth-scopes'} = {}) => (o
         return
     }
 
-    const oauthSchemes = pickBy(spec.components.securitySchemes, strategy => isMatch(strategy, {type: 'oauth2'}))
+    const oauthSchemes = pickBy(spec.components.securitySchemes, scheme => scheme.type === 'oauth2')
     const oauthNames = keys(oauthSchemes)
     const oauthStrategy = security.find(strategy => oauthNames.includes(keys(strategy).toString()))
 

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -1,6 +1,6 @@
 const oauthScopes = require('../../lib/middlewares/oauth/oauth-scopes')
 
-module.exports = ({grantedScopesLocation = 'headers.X-Oauth-Scopes'} = {}) => operation => {
+module.exports = ({grantedScopesLocation = 'headers.x-oauth-scopes'} = {}) => operation => {
     const [{oauth: requiredScopes}] = operation.security
     return oauthScopes(requiredScopes, grantedScopesLocation)
 }

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -1,6 +1,10 @@
 const oauthScopes = require('../../lib/middlewares/oauth/oauth-scopes')
 
 module.exports = ({grantedScopesLocation = 'headers.x-oauth-scopes'} = {}) => operation => {
+    if (!operation.security) {
+        return
+    }
+
     const [{oauth: requiredScopes}] = operation.security
     return oauthScopes(requiredScopes, grantedScopesLocation)
 }

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -1,13 +1,36 @@
+const {pickBy, isMatch, keys, values, flatten} = require('lodash')
+
 const oauthScopes = require('../../lib/middlewares/oauth/oauth-scopes')
 
-module.exports = ({grantedScopesLocation = 'headers.x-oauth-scopes'} = {}) => operation => {
-    if (!operation.security) {
+/**
+ * Verifies scope access to operation by comparing granted OAuth scopes and required scopes to perform that operation.
+ *
+ * Uses required OAuth scopes assigned to given operation or global security definition
+ * if the first one is not specified.
+ * Granted scopes are retrieved from `options.grantedScopesLocation`.
+ *
+ * In situation when there is more than one OAuth strategy assigned to operation the first one is taken for the check.
+ *
+ * To successfully pass through the middleware the request must have at least one of the required scopes.
+ * It is also possible to successfully pass through when request has undefined `options.grantedScopesLocation` property.
+ * On error `MissingRequiredScopes` error is created.
+ *
+ * @param {Object} options options
+ * @param {object} options.grantedScopesLocation request property to retrieve granted scopes
+ * @returns {Function} middleware
+ */
+module.exports = ({grantedScopesLocation = 'headers.x-oauth-scopes'} = {}) => (operation, {spec}) => {
+    const security = operation.security ? operation.security : spec.security
+
+    if (!security) {
         return
     }
 
-    const [{oauth: requiredScopes}] = operation.security
+    const oauthSchemes = pickBy(spec.components.securitySchemes, strategy => isMatch(strategy, {type: 'oauth2'}))
+    const oauthNames = keys(oauthSchemes)
+    const oauthStrategy = security.find(strategy => oauthNames.includes(keys(strategy).toString()))
 
-    if (requiredScopes) {
-        return oauthScopes(requiredScopes, grantedScopesLocation)
+    if (oauthStrategy) {
+        return oauthScopes(flatten(values(oauthStrategy)), grantedScopesLocation)
     }
 }

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -1,0 +1,6 @@
+const oauthScopes = require('../../lib/middlewares/oauth/oauth-scopes')
+
+module.exports = ({grantedScopesLocation = 'headers[\'X-Oauth-Scopes\']'} = {}) => operation => {
+    const [{oauth: requiredScopes}] = operation.security
+    return oauthScopes(requiredScopes, grantedScopesLocation)
+}

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -1,6 +1,6 @@
 const oauthScopes = require('../../lib/middlewares/oauth/oauth-scopes')
 
-module.exports = ({grantedScopesLocation = 'headers[\'X-Oauth-Scopes\']'} = {}) => operation => {
+module.exports = ({grantedScopesLocation = 'headers.X-Oauth-Scopes'} = {}) => operation => {
     const [{oauth: requiredScopes}] = operation.security
     return oauthScopes(requiredScopes, grantedScopesLocation)
 }

--- a/middlewares/oauth/oauth-scopes.js
+++ b/middlewares/oauth/oauth-scopes.js
@@ -6,5 +6,8 @@ module.exports = ({grantedScopesLocation = 'headers.x-oauth-scopes'} = {}) => op
     }
 
     const [{oauth: requiredScopes}] = operation.security
-    return oauthScopes(requiredScopes, grantedScopesLocation)
+
+    if (requiredScopes) {
+        return oauthScopes(requiredScopes, grantedScopesLocation)
+    }
 }

--- a/test/middlewares/oauth/oauth-scopes.spec.js
+++ b/test/middlewares/oauth/oauth-scopes.spec.js
@@ -92,4 +92,19 @@ describe('oauth scopes middleware', () => {
         // when
         expect(middleware).to.be.undefined
     })
+
+    it('should pass request when security property does not contain oauth', () => {
+        // given
+        const operation = {
+            security: [
+                {
+                    key: []
+                }
+            ]
+        }
+        const middleware = oauthScopes()(operation)
+
+        // when
+        expect(middleware).to.be.undefined
+    })
 })

--- a/test/middlewares/oauth/oauth-scopes.spec.js
+++ b/test/middlewares/oauth/oauth-scopes.spec.js
@@ -83,4 +83,13 @@ describe('oauth scopes middleware', () => {
         // when
         middleware(req, undefined, done)
     })
+
+    it('should pass request when security property not set on operation', () => {
+        // given
+        const operation = {}
+        const middleware = oauthScopes()(operation)
+
+        // when
+        expect(middleware).to.be.undefined
+    })
 })

--- a/test/middlewares/oauth/oauth-scopes.spec.js
+++ b/test/middlewares/oauth/oauth-scopes.spec.js
@@ -1,0 +1,86 @@
+const oauthScopes = require('../../../middlewares/oauth/oauth-scopes')
+const MissingRequiredScopes = require('../../../errors/MissingRequiredScopes')
+
+describe('oauth scopes middleware', () => {
+
+    it('should pass request containing required scopes in user', done => {
+        // given
+        const operation = {
+            security: [
+                {
+                    oauth: [
+                        'write',
+                        'read'
+                    ]
+                }
+            ]
+        }
+        const middleware = oauthScopes({grantedScopesLocation: 'user.grantedScopes'})(operation)
+        const req = {user: {grantedScopes: ['read']}}
+
+        // when
+        middleware(req, undefined, done)
+    })
+
+    it('should pass request containing required scopes in header', done => {
+        // given
+        const operation = {
+            security: [
+                {
+                    oauth: [
+                        'write',
+                        'read'
+                    ]
+                }
+            ]
+        }
+        const middleware = oauthScopes({grantedScopesLocation: 'headers[\'X-Oauth-Scopes\']'})(operation)
+        const req = {headers: {'X-Oauth-Scopes': ['read', 'write']}}
+
+        // when
+        middleware(req, undefined, done)
+    })
+
+    it('should indicate missing required scopes', () => {
+        const operation = {
+            security: [
+                {
+                    oauth: [
+                        'write',
+                        'execute'
+                    ]
+                }
+            ]
+        }
+        const middleware = oauthScopes({grantedScopesLocation: 'user.grantedScopes'})(operation)
+        const req = {user: {grantedScopes: ['read']}}
+        const next = sinon.spy()
+
+        // when
+        middleware(req, undefined, next)
+
+        // then
+        sinon.assert.calledWithMatch(next, sinon.match.instanceOf(MissingRequiredScopes)
+            .and(sinon.match.has('requiredScopes', operation.security.find(strategy => strategy.oauth).oauth)))
+    })
+
+    it('should pass request when granted scopes not set', done => {
+        // given
+        const operation = {
+            security: [
+                {
+                    oauth: [
+                        'write',
+                        'read'
+                    ],
+                    key: []
+                }
+            ]
+        }
+        const middleware = oauthScopes({grantedScopesLocation: 'user.grantedScopes'})(operation)
+        const req = {user: {}}
+
+        // when
+        middleware(req, undefined, done)
+    })
+})

--- a/test/middlewares/oauth/oauth-scopes.spec.js
+++ b/test/middlewares/oauth/oauth-scopes.spec.js
@@ -34,7 +34,7 @@ describe('oauth scopes middleware', () => {
                 }
             ]
         }
-        const middleware = oauthScopes({grantedScopesLocation: 'headers[\'X-Oauth-Scopes\']'})(operation)
+        const middleware = oauthScopes({grantedScopesLocation: 'headers.X-Oauth-Scopes'})(operation)
         const req = {headers: {'X-Oauth-Scopes': ['read', 'write']}}
 
         // when

--- a/test/middlewares/oauth/oauth-scopes.spec.js
+++ b/test/middlewares/oauth/oauth-scopes.spec.js
@@ -34,8 +34,8 @@ describe('oauth scopes middleware', () => {
                 }
             ]
         }
-        const middleware = oauthScopes({grantedScopesLocation: 'headers.X-Oauth-Scopes'})(operation)
-        const req = {headers: {'X-Oauth-Scopes': ['read', 'write']}}
+        const middleware = oauthScopes({grantedScopesLocation: 'headers.x-oauth-scopes'})(operation)
+        const req = {headers: {'x-oauth-scopes': ['read', 'write']}}
 
         // when
         middleware(req, undefined, done)

--- a/test/middlewares/oauth/oauth-scopes.spec.js
+++ b/test/middlewares/oauth/oauth-scopes.spec.js
@@ -43,7 +43,7 @@ describe('oauth scopes middleware', () => {
 
     it('should pass request containing required scopes in header', done => {
         // given
-        const middleware = oauthScopes({grantedScopesLocation: 'headers.x-oauth-scopes'})(operation, {spec})
+        const middleware = oauthScopes()(operation, {spec})
         const req = {headers: {'x-oauth-scopes': ['read', 'write']}}
 
         // when


### PR DESCRIPTION
## Description

This PR introduces new OAuth middleware that performs check if granted OAuth scopes are sufficient to perform operation. 

Required scopes are obtained from OpenAPI Specification for given operation. Granted scopes are retrieved from request (more precisely, from passed `grantedScopesLocation` options argument (like `'headers[\'X-Oauth-Scopes\']'` or `'user.grantedScopes'`). 

To successfully pass through the filter the request must have **at least one** of the required scopes. It is also possible to successfully pass through when request has undefined `grantedScopesLocation` property so any other authentication methods won't be affected by this middleware. On error, `MissingRequiredScopes` error is created.