### PR TITLE
Remove uuid dependency & update dependencies

### DIFF
--- a/lib/middleware-once-per-req.js
+++ b/lib/middleware-once-per-req.js
@@ -1,7 +1,5 @@
-const uuid = require('uuid')
-
 module.exports = () => {
-    const middlewareId = uuid()
+    const middlewareId = Symbol()
 
     return middleware => (req, res, next) => {
         req._openApiFirst = req._openApiFirst || {usedMiddlewares: []}

--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "lodash": "4.17.14",
-    "type-is": "1.6.18",
-    "uuid": "3.3.2"
+    "lodash": "4.17.15",
+    "type-is": "1.6.18"
   },
   "devDependencies": {
     "@smartrecruiters/eslint-config": "4.3.0",
@@ -22,7 +21,7 @@
     "eslint": "5.16.0",
     "eslint-plugin-security": "1.4.0",
     "express": "4.17.1",
-    "mocha": "6.1.4",
+    "mocha": "6.2.0",
     "nyc": "14.1.1",
     "sinon": "7.3.2"
   },


### PR DESCRIPTION
## Description

`Symbol` could be used instead of `uuid` as well and no external dependency is needed.