### PR TITLE
fix: resolve parameters schema refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ The response should be 200 with body:
 
 ## openapi middlewares
 
-You can use one of the middlewares under `@smartrecruiters/middlewares/*` or create your own. Such middlewares will be 
-applied to connect-style app for each operation as they are specification and operation aware. For instace, 
-`@smartrecruiters/middlewares/query/validate` middleware will be applied to any and only operation which has query 
-parameters defined, passing an Error to `next` callback when `req.query` is invalid. 
+You can use one of the middlewares under `@smartrecruiters/middlewares/*` or create your own. Such middlewares will be
+applied to connect-style app for each operation as they are specification and operation aware. For instace,
+`@smartrecruiters/middlewares/query/validate` middleware will be applied to any and only operation which has query
+parameters defined, passing an Error to `next` callback when `req.query` is invalid.
 
 Currently following middlewares are available:
 - request body validation,
@@ -147,7 +147,7 @@ The recommended schema validator is [`@smartrecruiters/openapi-schema-validator`
 ### Create your own openapi middleware
 
 Adding your own openapi is very simple. Let's say your operation has extension
-[OpenAPI Specification 3.0 Specification Extension](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions) 'x-only-admin'. 
+[OpenAPI Specification 3.0 Specification Extension](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#specificationExtensions) 'x-only-admin'.
 If it is set on, this will mean that only users with admin can use this method.
 Assuming some preceding middleware is setting `req.user.role`, you can write a simple openapi middleware
 that will gather information from operation object and act accordingly:
@@ -177,5 +177,5 @@ Please see our [Code of conduct](docs/CODE_OF_CONDUCT.md) and [Contributing guid
 [node-version-url]: https://nodejs.org/en/download/
 [license-url]: https://github.com/smartrecruiters/openapi-first/blob/master/LICENSE
 [license-image]: https://img.shields.io/npm/l/@smartrecruiters/openapi-first.svg
-[travis-url]: https://travis-ci.org/smartrecruiters/openapi-first
-[travis-image]: https://api.travis-ci.org/smartrecruiters/openapi-first.svg?branch=master
+[travis-url]: https://travis-ci.com/smartrecruiters/openapi-first
+[travis-image]: https://api.travis-ci.com/smartrecruiters/openapi-first.svg?branch=master

--- a/lib/utils/ref-resolver.js
+++ b/lib/utils/ref-resolver.js
@@ -1,4 +1,4 @@
-const {get} = require('lodash')
+const {get, has} = require('lodash')
 
 const isRef = obj => typeof obj.$ref === 'string'
 
@@ -9,7 +9,17 @@ const ptrToPath = ptr => {
 }
 
 function resolve(spec, obj) {
-    return isRef(obj) ? resolve(spec, get(spec, ptrToPath(obj.$ref))) : obj
+    if (isRef(obj)) {
+        return resolve(spec, get(spec, ptrToPath(obj.$ref)))
+    }
+
+    // Check for {schema: {$ref: ...}}
+    if (has(obj, 'schema') && isRef(obj.schema)) {
+        obj.schema = resolve(spec, get(spec, ptrToPath(obj.schema.$ref)))
+        return obj
+    }
+
+    return obj
 }
 
 module.exports = spec => obj => resolve(spec, obj)

--- a/test/lib/utils/ref-resolver.spec.js
+++ b/test/lib/utils/ref-resolver.spec.js
@@ -1,0 +1,57 @@
+const refResolver = require('../../../lib/utils/ref-resolver')
+
+describe('refResolver util', () => {
+
+    const expectedParam1 = {
+        name: 'p1',
+        schema: {
+            type: 'string',
+            enum: ['x1', 'x2', 'x3'],
+            default: 'x2'
+        }
+    }
+
+    const expectedParam2 = {
+        name: 'size',
+        type: 'integer',
+        default: 10
+    }
+
+    const validSpec = {
+        paths: {
+            '/a': {
+                get: {
+                    operationId: 'a',
+                    parameters: [
+                        {name: 'p1', schema: {$ref: '#/components/schemas/Schema1'}},
+                        {$ref: '#/components/schemas/Schema2'}
+                    ]
+                }
+            }
+        },
+        components: {
+            schemas: {
+                Schema1: {
+                    type: 'string',
+                    enum: ['x1', 'x2', 'x3'],
+                    default: 'x2'
+                },
+                Schema2: {
+                    name: 'size',
+                    type: 'integer',
+                    default: 10
+                }
+            }
+        }
+    }
+
+    it('should resolve refs', () => {
+        // when
+        const resolvedParameter1 = refResolver(validSpec)(validSpec.paths['/a'].get.parameters[0])
+        const resolvedParameter2 = refResolver(validSpec)(validSpec.paths['/a'].get.parameters[1])
+
+        // then
+        expect(resolvedParameter1).to.eql(expectedParam1)
+        expect(resolvedParameter2).to.eql(expectedParam2)
+    })
+})


### PR DESCRIPTION
Currently we only resolve root level parameter refs

e.g. 
```yaml
paths:
  /teams:
    get:
      summary: Gets a list of teams.
      parameters:
        - $ref: '#/components/parameters/offsetParam'
        - $ref: '#/components/parameters/limitParam'
```

This change will also resolve refs under the `schema` key.
e.g.
```yaml
paths:
  /search:
    get:
      operationId: search
      parameters:
        - in: query
          name: language
          schema:
            $ref: '#/components/schemas/LanguageCodes'
```